### PR TITLE
Enable batched faster-whisper transcription

### DIFF
--- a/ARCH.md
+++ b/ARCH.md
@@ -90,6 +90,13 @@ layers. Engine-specific data that doesn't fit the schema lives in
 - **`WhisperSession`** is the shared session implementation reused by both
   faster-whisper and stable-whisper. It buffers PCM frames and emits segments
   with confidence-based filtering, deferring final segments until `flush()`.
+- **`FasterWhisperModel` batched path** — when `transcribe(..., batch_size=N)`
+  is called with `N > 1`, the wrapper switches from
+  `faster_whisper.WhisperModel.transcribe` to
+  `faster_whisper.BatchedInferencePipeline.transcribe` while keeping the
+  public `ivrit` API unchanged. Additional transcription kwargs such as
+  `beam_size`, `vad_filter`, and `batch_size` are forwarded to the
+  faster-whisper backend call.
 - **`RunPodJob` / `AsyncRunPodJob`** are the sync/async polling helpers that wrap
   a RunPod inference job and stream results back as they become available.
   The RunPod stream protocol carries two kinds of items inside `data['stream']`:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,24 @@ for segment in model.transcribe(path="audio.mp3", stream=True):
         print(f"  {word['start']:.2f}s - {word['end']:.2f}s: '{word['word']}'")
 ```
 
+#### Batched faster-whisper transcription
+
+For faster-whisper, you can pass `batch_size` through `transcribe()` to switch
+to the backend's batched inference path:
+
+```python
+model = ivrit.load_model(
+    engine="faster-whisper",
+    model="ivrit-ai/whisper-large-v3-turbo-ct2",
+)
+
+result = model.transcribe(
+    path="audio.mp3",
+    language="he",
+    batch_size=8,
+)
+```
+
 #### Async Transcription (RunPod Only)
 
 For RunPod models, you can use async transcription for better performance:
@@ -122,7 +140,7 @@ Transcribe audio using the loaded model.
 - **stream** (`bool`, optional): Whether to return results as a generator (True) or full result (False) - only for `transcribe()`
 - **diarize** (`bool`, optional): Whether to enable speaker diarization
 - **verbose** (`bool`, optional): Whether to enable verbose output
-- **\*\*kwargs**: Additional keyword arguments for the transcription model
+- **\*\*kwargs**: Additional keyword arguments forwarded to the transcription backend. For `faster-whisper`, this includes options such as `batch_size`, `beam_size`, and `vad_filter`.
 
 #### Returns
 

--- a/ivrit/audio.py
+++ b/ivrit/audio.py
@@ -646,6 +646,7 @@ class FasterWhisperModel(TranscriptionModel):
         self.device = device if device else utils.guess_device()
         self.local_files_only = local_files_only
         self.model_kwargs = kwargs
+        self._batched_model = None
         
         # Load the model immediately
         self.model_object = self._load_faster_whisper_model()
@@ -689,6 +690,32 @@ class FasterWhisperModel(TranscriptionModel):
         
         logger.info(f'Loading faster-whisper model: {self.model_path} on {device} with index: {device_index or 0}')
         return faster_whisper.WhisperModel(self.model_path, **args)
+
+    def _get_faster_whisper_transcriber(self, batch_size: Any = None) -> Any:
+        """
+        Return the appropriate faster-whisper transcriber implementation.
+
+        When batch_size > 1, use faster-whisper's BatchedInferencePipeline.
+        Otherwise, keep using the plain WhisperModel path.
+        """
+        should_batch = False
+        if batch_size is not None:
+            try:
+                should_batch = int(batch_size) > 1
+            except (TypeError, ValueError):
+                should_batch = True
+
+        if not should_batch:
+            return self.model_object
+
+        if self._batched_model is None:
+            import faster_whisper
+
+            self._batched_model = faster_whisper.BatchedInferencePipeline(
+                model=self.model_object
+            )
+
+        return self._batched_model
     
     def create_session(self, language: Optional[str] = None, sample_rate: int = 16000, 
                       verbose: bool = False) -> TranscriptionSession:
@@ -751,9 +778,16 @@ class FasterWhisperModel(TranscriptionModel):
                 logger.info("Diarization is enabled")
 
         try:
-            # Transcribe using faster-whisper directly with file path
-            # Enable word timestamps if requested
-            segments, info = self.model_object.transcribe(audio_path, language=language, word_timestamps=output_options['word_timestamps'])
+            transcribe_kwargs = {
+                "language": language,
+                "word_timestamps": output_options["word_timestamps"],
+            }
+            transcribe_kwargs.update(kwargs)
+
+            transcriber = self._get_faster_whisper_transcriber(
+                transcribe_kwargs.get("batch_size")
+            )
+            segments, info = transcriber.transcribe(audio_path, **transcribe_kwargs)
             total_seconds = getattr(info, "duration", None)
 
             # Collect segments for diarization if needed

--- a/tests/test_batch_transcription.py
+++ b/tests/test_batch_transcription.py
@@ -1,0 +1,97 @@
+import types
+from types import SimpleNamespace
+
+from ivrit.audio import FasterWhisperModel
+
+
+class DummySegment:
+    def __init__(self, text: str, start: float, end: float):
+        self.text = text
+        self.start = start
+        self.end = end
+        self.words = []
+
+
+class DummyWhisperModel:
+    def __init__(self):
+        self.calls = []
+
+    def transcribe(self, audio, **kwargs):
+        self.calls.append((audio, kwargs))
+        return iter([DummySegment("hello", 0.0, 1.0)]), SimpleNamespace(duration=1.0)
+
+
+class DummyBatchedInferencePipeline:
+    def __init__(self, model):
+        self.model = model
+        self.calls = []
+
+    def transcribe(self, audio, **kwargs):
+        self.calls.append((audio, kwargs))
+        return iter([DummySegment("hello", 0.0, 1.0)]), SimpleNamespace(duration=1.0)
+
+
+def _install_fake_dependencies(monkeypatch):
+    import ivrit.audio as audio_module
+    import ivrit.utils as utils_module
+
+    fake_module = types.ModuleType("faster_whisper")
+    fake_module.WhisperModel = lambda *args, **kwargs: DummyWhisperModel()
+    fake_module.BatchedInferencePipeline = DummyBatchedInferencePipeline
+
+    monkeypatch.setattr(
+        utils_module,
+        "check_dependencies",
+        lambda module_specs, feature_name="": {
+            name: object() for name in module_specs
+        },
+    )
+    monkeypatch.setattr(utils_module, "guess_device", lambda: "cpu")
+    monkeypatch.setattr(
+        utils_module,
+        "get_audio_file_path",
+        lambda **kwargs: kwargs["path"],
+    )
+    monkeypatch.setattr(audio_module, "get_device_and_index", lambda device: (device, None))
+    monkeypatch.setitem(__import__("sys").modules, "faster_whisper", fake_module)
+
+
+def test_faster_whisper_forwards_extra_transcribe_kwargs(monkeypatch):
+    _install_fake_dependencies(monkeypatch)
+    model = FasterWhisperModel(model="dummy")
+
+    result = model.transcribe(path="audio.mp3", language="he", beam_size=3, vad_filter=True)
+
+    assert result["text"] == "hello"
+    assert model.model_object.calls == [
+        (
+            "audio.mp3",
+            {
+                "language": "he",
+                "word_timestamps": True,
+                "beam_size": 3,
+                "vad_filter": True,
+            },
+        ),
+    ]
+
+
+def test_faster_whisper_uses_batched_pipeline_when_batch_size_requested(monkeypatch):
+    _install_fake_dependencies(monkeypatch)
+    model = FasterWhisperModel(model="dummy")
+
+    result = model.transcribe(path="audio.mp3", language="he", batch_size=8)
+
+    assert result["text"] == "hello"
+    assert isinstance(model._batched_model, DummyBatchedInferencePipeline)
+    assert model._batched_model.calls == [
+        (
+            "audio.mp3",
+            {
+                "language": "he",
+                "word_timestamps": True,
+                "batch_size": 8,
+            },
+        ),
+    ]
+    assert model.model_object.calls == []


### PR DESCRIPTION
## Summary
- forward `transcribe()` kwargs to the faster-whisper backend
- switch to `BatchedInferencePipeline` when `batch_size > 1`
- document the new batching path and add focused unit tests

## Root cause
The current `FasterWhisperModel.transcribe_core()` accepts `**kwargs`, but never forwards them to the backend call. This means options like `batch_size`, `beam_size`, or `vad_filter` are silently dropped.

Because of that, callers cannot activate faster-whisper's documented batched inference path through ivrit's public `transcribe()` API.

## What changed
- keep the existing single-file API unchanged
- lazily instantiate `faster_whisper.BatchedInferencePipeline` when `batch_size > 1`
- continue to use the plain `WhisperModel` path otherwise
- pass transcription kwargs through to the backend call instead of dropping them

## Validation
- `/Library/Frameworks/Python.framework/Versions/3.12/bin/pytest tests/test_batch_transcription.py -q`
- `python3 -m py_compile ivrit/audio.py tests/test_batch_transcription.py`
- `git diff --check`

## Notes
This is intentionally scoped to the faster-whisper path only. It does not try to redesign the API for multi-input batching yet; it enables the batching mechanism that faster-whisper already documents, through ivrit's existing `transcribe()` entrypoint.

Closes #13.